### PR TITLE
fix & patch

### DIFF
--- a/downloaders/http/simple-downloader.go
+++ b/downloaders/http/simple-downloader.go
@@ -93,6 +93,11 @@ func PerformSimpleDownload(url string, outputPath string, client *http.Client, p
 			return fmt.Errorf("error reading response body: %v", err)
 		}
 	}
+	// Ensure file is synced and closed (while auto-handled in Unix, Windows needs this)
+	outFile.Sync()
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("error closing output file: %v", err)
+	}
 	if err := os.Rename(tempOutputPath, outputPath); err != nil {
 		return fmt.Errorf("error renaming (finalizing) output file: %v", err)
 	}

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -55,9 +55,9 @@ func ReadDownloadList(filePath string) ([]DownloadEntry, error) {
 		if entry.URL == "" {
 			return nil, fmt.Errorf("missing URL for entry %d", i+1)
 		}
-		if entry.OutputPath == "" {
-			return nil, fmt.Errorf("missing output path for entry %d", i+1)
-		}
+		// if entry.OutputPath == "" {
+		// 	return nil, fmt.Errorf("missing output path for entry %d", i+1)
+		// }
 	}
 	return entries, nil
 }


### PR DESCRIPTION
fixes #14 

renaming error should be eliminated. files for simpledownloader were being closed with `defer` but being renamed before that, causing an open-error. this wasn't an issue on unix but on windows.

output paths are no longer required to be present in the batchyaml file.