### PR TITLE
fix: clamp progress percentage to prevent panic

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -358,7 +358,15 @@ func (d *Display) buildDisplay() []string {
 				extraInfo = truncateString(extraInfo, innerWidth-4-1-1-6-progressWidth)
 			}
 
-			pct := float64(job.Current) / float64(job.Total)
+			var pct float64
+			if job.Total > 0 {
+				pct = float64(job.Current) / float64(job.Total)
+			}
+			if pct > 1.0 {
+				pct = 1.0
+			} else if pct < 0 {
+				pct = 0
+			}
 			filled := int(pct * float64(progressWidth))
 			empty := progressWidth - filled
 


### PR DESCRIPTION
Fixes panic with negative repeat count in display progress bar

---
*PR created automatically by Jules for task [14519133909688309988](https://jules.google.com/task/14519133909688309988) started by @Tanq16*